### PR TITLE
Fix: getContent re-renders first content section if section's layout have matching names

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Thanks to Inertia, page data will be passed to the views automatically as an arr
 ```vue
 // About.vue
 <template>
-    <div v-html="getSectionContent(content[0].layout).content"></div>
+    <div v-html="getSectionContent(content[0]).content"></div>
 </template>
 
 <script>

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Thanks to Inertia, page data will be passed to the views automatically as an arr
 ```vue
 // About.vue
 <template>
-    <div v-html="getSectionContent(content[0].section).content"></div>
+    <div v-html="getSectionContent(content[0].layout).content"></div>
 </template>
 
 <script>

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ To create new page layouts that will be available in the CMS, create a php file 
 This package is set up to use Inertia by default. To add an Inertia page, create a new Directory and Index.vue file in `resources/js/Pages`. You can see the `Default` Page as an example. The config file and Vue directory names need to be identical.
 
 ### Accessing Content
-Page data will be passed to the views automatically, thanks to Inertia. To get specific section data, we have a Vue mixin called `SectionContent` that will return the content for a given section.
-```
+Thanks to Inertia, page data will be passed to the views automatically as an array. To get specific section data, we have a Vue mixin called `SectionContent` that returns an object containing the data for a given section.
+```vue
 // About.vue
 <template>
-    <div v-html="getSection('intro').content"></div>
+    <div v-html="getSectionContent(content[0].section).content"></div>
 </template>
 
 <script>
@@ -128,7 +128,24 @@ export default {
 }
 </script>
 ```
-This will get the content for a section with the slug “intro” from the layout’s config file.
+
+Or dynamically render all sections passed to the component:
+```vue
+<template>
+    <div v-for="section in content"
+        :key="section.key"
+        v-html="getSectionContent(section).content" />
+</template>
+
+<script>
+import SectionContent from '@/PageBuilder/mixins/SectionContent';
+
+export default { 
+    props: ['page', 'content'],
+    mixins: [SectionContent],
+}
+</script>
+```
 
 ## Meta Information
 To inject the meta information into the layout view, add the `<Head />` component to the `<template>` of the `AppLayout.vue` file.  

--- a/resources/js/PageBuilder/mixins/SectionContent.js
+++ b/resources/js/PageBuilder/mixins/SectionContent.js
@@ -9,7 +9,17 @@
 export default {
     props: ['content'],
     methods: {
-        getSection(slug) {
+        getSection(slug, key = null) {
+            if (key) {
+                const section = this.content.find((s) => s.layout === slug && s.key === key);
+
+                if (section) {
+                    return section.attributes;
+                }
+                
+                return false;
+            }
+
             const section = this.content.filter((section) => {
                 return section.layout === slug;
             });

--- a/resources/js/PageBuilder/mixins/SectionContent.js
+++ b/resources/js/PageBuilder/mixins/SectionContent.js
@@ -30,5 +30,8 @@ export default {
 
             return false;
         },
+        getSectionContent(section) {
+            return section.attributes;
+        },
     }
 }

--- a/resources/js/Pages/Default/Index.vue
+++ b/resources/js/Pages/Default/Index.vue
@@ -1,9 +1,9 @@
 <template>
     <app-layout>
-        <div v-for="section in content">
-            <Hero :content="getSection(section.layout)" v-if="section.layout === 'hero'" />
-            <OneColumnLayout :content="getSection(section.layout)" v-if="section.layout === 'one-column-layout'" />
-            <TwoColumnLayout :content="getSection(section.layout)" v-if="section.layout === 'two-column-layout'" />
+        <div v-for="section in content" :key="section.key">
+            <Hero :content="section.attributes" v-if="section.layout === 'hero'" />
+            <OneColumnLayout :content="section.attributes" v-if="section.layout === 'one-column-layout'" />
+            <TwoColumnLayout :content="section.attributes" v-if="section.layout === 'two-column-layout'" />
         </div>
     </app-layout>
 </template>

--- a/resources/js/Pages/Default/Index.vue
+++ b/resources/js/Pages/Default/Index.vue
@@ -1,9 +1,9 @@
 <template>
     <app-layout>
         <div v-for="section in content" :key="section.key">
-            <Hero :content="section.attributes" v-if="section.layout === 'hero'" />
-            <OneColumnLayout :content="section.attributes" v-if="section.layout === 'one-column-layout'" />
-            <TwoColumnLayout :content="section.attributes" v-if="section.layout === 'two-column-layout'" />
+            <Hero :content="getSectionContent(section)" v-if="section.layout === 'hero'" />
+            <OneColumnLayout :content="getSectionContent(section)" v-if="section.layout === 'one-column-layout'" />
+            <TwoColumnLayout :content="getSectionContent(section)" v-if="section.layout === 'two-column-layout'" />
         </div>
     </app-layout>
 </template>


### PR DESCRIPTION
### The Problem

When using `getSection` in from the mixin, if multiple sections with the same layout are passed the first section is rendered correctly but all subsequent sections are rendered with the first's content. Example:

```json
[
  {
    "key": "aabbcc",
    "layout": "one-column-layout",
    "attributes": {
      "content": "<p>Content 1</p>"
    }
  },
  {
    "key": "ccbbaa",
    "layout": "one-column-layout",
    "attributes": {
      "content": "<p>Content 2</p>"
    }
  }
]
```

`getSection` would render `<p>Content 1</p>` in both `div` elements.

```vue
<template>
    <template v-for="section in content"
        :key="section.key">
        <div v-html="getContent('one-column-layout')?.content" />
    </template>
</template>
<script>
import SectionContent from '@/PageBuilder/mixins/SectionContent';
export default { 
    props: ['page', 'content'],
    mixins: [SectionContent],
}
</script>
```

### The Fix

The fix is a backwards compatible workaround that will require any package users to update the way they use `getContent` in the above scenario. The changes will allow any currant usage to remain intact without any changes to existing code.

1. Added `key` to `getSection` so it can return early with a specific object rather if `key` is provided. Otherwise functionality remains the same. 
2. Added `getSectionContent` that simply returns the inner `attributes` property.
3. Updated `resources/js/Pages/Default/Index.vue` to use `getSectionContent`
4. Updated docs.
